### PR TITLE
Module Federation形式のビルドを実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>XRift Test World</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@xrift/test-world",
       "version": "0.1.2",
       "devDependencies": {
+        "@originjs/vite-plugin-federation": "^1.4.1",
         "@types/react": "^19.1.9",
         "@types/react-dom": "^19.1.7",
         "@types/three": "^0.176.0",
@@ -964,6 +965,44 @@
       },
       "peerDependencies": {
         "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@originjs/vite-plugin-federation": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@originjs/vite-plugin-federation/-/vite-plugin-federation-1.4.1.tgz",
+      "integrity": "sha512-Uo08jW5pj1t58OUKuZNkmzcfTN2pqeVuAWCCiKf/75/oll4Efq4cHOqSE1FXMlvwZNGDziNdDyBbQ5IANem3CQ==",
+      "dev": true,
+      "license": "MulanPSL-2.0",
+      "dependencies": {
+        "estree-walker": "^3.0.2",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "pnpm": ">=7.0.1"
+      }
+    },
+    "node_modules/@originjs/vite-plugin-federation/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@originjs/vite-plugin-federation/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@react-three/drei": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@xrift/test-world",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/remoteEntry.js",
+  "module": "./dist/remoteEntry.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "import": "./dist/remoteEntry.js",
       "types": "./dist/index.d.ts"
     }
   },
@@ -29,6 +29,7 @@
     "three": "^0.176.0"
   },
   "devDependencies": {
+    "@originjs/vite-plugin-federation": "^1.4.1",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",
     "@types/three": "^0.176.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
+import federation from '@originjs/vite-plugin-federation'
 
 export default defineConfig({
   plugins: [
@@ -9,43 +10,53 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
     }),
-  ],
-  build: {
-    lib: {
-      entry: path.resolve(__dirname, 'src/index.tsx'),
-      name: 'XRiftTestWorld',
-      formats: ['es'],
-      fileName: () => 'index.js',
-    },
-    rollupOptions: {
-      external: [
-        'react',
-        'react-dom',
-        'react/jsx-runtime',
-        'three',
-        '@react-three/fiber',
-        '@react-three/rapier',
-        '@react-three/drei',
-      ],
-      output: {
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-          three: 'THREE',
+    federation({
+      name: 'xrift_test_world',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './World': './src/index.tsx',
+      },
+      shared: {
+        react: {
+          singleton: true,
+          requiredVersion: '^19.0.0',
+        },
+        'react-dom': {
+          singleton: true,
+          requiredVersion: '^19.0.0',
+        },
+        'react/jsx-runtime': {
+          singleton: true,
+        },
+        three: {
+          singleton: true,
+          requiredVersion: '^0.176.0',
+        },
+        '@react-three/fiber': {
+          singleton: true,
+          requiredVersion: '^9.3.0',
+        },
+        '@react-three/rapier': {
+          singleton: true,
+          requiredVersion: '^2.1.0',
+        },
+        '@react-three/drei': {
+          singleton: true,
+          requiredVersion: '^10.7.3',
         },
       },
-    },
+    }),
+  ],
+  build: {
+    target: 'esnext',
+    minify: false,
+    cssCodeSplit: false,
+    assetsDir: '',
   },
   resolve: {
     alias: {
       '~': path.resolve(__dirname, './src'),
     },
-    dedupe: ['three', '@react-three/fiber', 'react', 'react-dom'],
-  },
-  optimizeDeps: {
-    include: [
-      '@react-three/rapier',
-    ],
   },
   define: {
     global: 'globalThis',


### PR DESCRIPTION
## 概要
issue #4 の対応として、Module Federation形式のビルドを実装しました。

## 変更内容
- **@originjs/vite-plugin-federation**を導入
- **vite.config.ts**をModule Federation設定に変更
  - `singleton: true`で依存関係（React, React DOM, Three.js, @react-three/fiber, @react-three/rapier, @react-three/drei）を共有
  - `exposes`で`./World`としてコンポーネントをエクスポート
- **package.json**のエントリーポイントを`./dist/remoteEntry.js`に更新
- **index.html**を追加（開発・ビルド用）
- バージョンを**0.2.0**に更新

## 解決する問題
- XRift本体と動的ロードされたワールドで異なるReact/Three.jsインスタンスが生成される問題を解決
- "React Invalid Hook Call"エラーの解消
- グローバル汚染のない設計を実現

## テスト計画
- [x] ローカルビルドが成功することを確認
- [x] remoteEntry.jsが正しく生成されることを確認
- [x] TypeScript型定義ファイルが生成されることを確認
- [ ] XRift側で動的ロードして動作確認
- [ ] npmパッケージとして公開

## 関連issue
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)