### PR TITLE
feat: Module Federation共有ライブラリをignoreに追加してアップロードサイズを削減

### DIFF
--- a/xrift.json
+++ b/xrift.json
@@ -10,7 +10,16 @@
       "**/Thumbs.db",
       "**/*.js.map",
       "**/.gitkeep",
-      "**/index.html"
+      "**/index.html",
+      "**/__federation_shared_@react-three/drei-*.js",
+      "**/__federation_shared_@react-three/fiber-*.js",
+      "**/__federation_shared_@react-three/rapier-*.js",
+      "**/__federation_shared_@xrift/world-components-*.js",
+      "**/__federation_shared_three-*.js",
+      "**/__federation_shared_react-*.js",
+      "**/__federation_shared_react-dom-*.js",
+      "**/rapier.es-*.js",
+      "**/hls-*.js"
     ]
   }
 }


### PR DESCRIPTION
## 概要

XRiftプラットフォーム側で提供される共有ライブラリを`xrift.json`の`ignore`設定に追加することで、ワールドのアップロードサイズを約82%削減（8.9MB → 1.6MB）します。

## 変更内容

`xrift.json`に以下のignoreパターンを追加：

### Module Federation共有ライブラリ
- `__federation_shared_@react-three/drei-*.js` (2.1MB)
- `__federation_shared_three-*.js` (1.5MB)
- `__federation_shared_@react-three/fiber-*.js` (448KB)
- `__federation_shared_react-*.js` / `react-dom-*.js` (数百KB)
- `__federation_shared_@react-three/rapier-*.js` (64KB)
- `__federation_shared_@xrift/world-components-*.js`

### 物理・メディアライブラリ
- `rapier.es-*.js` (2.0MB) - Rapier物理エンジン
- `hls-*.js` (1.1MB) - HLSストリーミングライブラリ

## 効果

- **アップロードサイズ**: 8.9MB → 1.6MB（約82%削減）
- 共有ライブラリはXRiftプラットフォーム側から提供されるため、ワールドは正常に動作
- 独自パッケージを追加した場合も安全にアップロードされる

## 技術的背景

これらのライブラリは`vite.config.ts`の`shared`設定に含まれており、Module Federationによってプラットフォーム側から動的に提供されます。そのため、ワールド側にバンドルする必要がなく、ignoreして問題ありません。

## テスト

実際のワールドで検証済み：
- ✅ アップロードサイズが1.6MBに削減
- ✅ ワールドは正常に動作（共有ライブラリはプラットフォーム側から提供される）
- ✅ 独自パッケージを追加しても安全

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)