### PR TITLE
feat: useInstanceStateを使ったグローバルステート機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,79 @@ function InteractiveButton() {
 
 詳細な実装は`src/components/InteractableButton/index.tsx`と`src/World.tsx`を参照してください。
 
+#### インスタンス全体で同期される状態管理（useInstanceState）
+
+`@xrift/world-components`の`useInstanceState`フックを使用すると、同じワールドインスタンス内の全ユーザー間で状態を同期できます。これにより、マルチユーザー対応のインタラクティブなワールドを簡単に作成できます。
+
+```typescript
+import { useInstanceState } from '@xrift/world-components'
+
+function GlobalCounter() {
+  // インスタンス全体で同期されるカウンター
+  const [count, setCount] = useInstanceState<number>('global-counter', 0)
+
+  const handleClick = () => {
+    setCount((prev) => prev + 1)
+  }
+
+  return (
+    <Interactable id="counter" onInteract={handleClick}>
+      <mesh>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color={count > 5 ? 'green' : 'blue'} />
+      </mesh>
+    </Interactable>
+  )
+}
+```
+
+##### useInstanceStateの使い方
+
+```typescript
+const [state, setState] = useInstanceState<T>(stateId, initialState)
+```
+
+**パラメータ:**
+- `stateId`: 状態の一意識別子（インスタンス内で一意である必要があります）
+- `initialState`: 初期状態値
+- `setState`: 状態を更新する関数（Reactの`useState`と同じAPI）
+
+**更新パターン:**
+```typescript
+// 直接値を設定
+setState({ enabled: true })
+
+// 関数型アップデート
+setState(prev => ({ enabled: !prev.enabled }))
+```
+
+**重要な注意点:**
+- 状態はJSON形式でシリアライズ可能である必要があります
+- プラットフォーム側がWebSocketを通じて全クライアント間の同期を実現します
+- ローカル開発環境（Context未設定時）では通常の`useState`として動作します
+
+##### ローカルステートとグローバルステートの使い分け
+
+このテンプレートの`InteractableButton`コンポーネントは、`useGlobalState`プロパティで動作を切り替えられる実装例を提供しています：
+
+```typescript
+// ローカルステート（各ユーザーごとに独立）
+<InteractableButton
+  id="local-button"
+  label="ローカル"
+  useGlobalState={false}
+/>
+
+// グローバルステート（全ユーザー間で同期）
+<InteractableButton
+  id="global-button"
+  label="グローバル"
+  useGlobalState={true}
+/>
+```
+
+実装の詳細は`src/components/InteractableButton/index.tsx`を参照してください。
+
 ## .xriftディレクトリについて
 
 `.xrift/`ディレクトリには、ワールドの設定情報（ワールドIDなど）がローカル環境固有の情報として保存されます。このディレクトリは`.gitignore`に含まれており、リポジトリにコミットされません。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/world-template",
       "version": "1.0.0",
       "dependencies": {
-        "@xrift/world-components": "^0.2.5"
+        "@xrift/world-components": "^0.5.0"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1889,9 +1889,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.2.5.tgz",
-      "integrity": "sha512-aNXoVk1uGC3B5oJmEjAt5pdQH3oHAH4HiNdtB2qlojdsjj0qL5u/LX/jWyCCqP+70SLagbtkNg2dpZ2jDrFgdQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.5.0.tgz",
+      "integrity": "sha512-hbtOjhYiU1XWmVt/nBwCThCrF77M+SgPFg98zaxlgRz/yMnCZoReslvsQMbq8bVL1F5AXuIOLVu2XrfQqTywOQ==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.2.5"
+    "@xrift/world-components": "^0.5.0"
   }
 }

--- a/src/World.tsx
+++ b/src/World.tsx
@@ -197,20 +197,22 @@ export const World: React.FC<WorldProps> = ({ position = [0, 0, 0], scale = 1 })
         <Duck position={[-2, 0.5, 0]} scale={1} />
       </RigidBody>
 
-      {/* Interactableボタン - クリック可能なオブジェクトの例 */}
+      {/* Interactableボタン - クリック可能なオブジェクトの例（ローカルステート） */}
       <InteractableButton
         position={[0, 1, -3]}
         id="sample-button-1"
-        label="押してね！"
+        label="ローカル"
         interactionText="ボタンをクリック"
+        useGlobalState={false}
       />
 
-      {/* 別のInteractableボタン */}
+      {/* 別のInteractableボタン（グローバルステート - インスタンス全体で同期） */}
       <InteractableButton
         position={[2.5, 1, -3]}
         id="sample-button-2"
-        label="カウンター"
+        label="グローバル"
         interactionText="カウントアップ"
+        useGlobalState={true}
       />
     </group>
   )


### PR DESCRIPTION
## 概要

`@xrift/world-components`の`useInstanceState`フックを使用して、インスタンス内の全ユーザー間で状態を同期できるグローバルステート機能を追加しました。

## 変更内容

### 機能追加
- ✨ `InteractableButton`コンポーネントに`useInstanceState`フックを実装
- 🔀 `useGlobalState`プロパティでローカル/グローバルステートを切り替え可能に
- 📦 ローカルステート（各ユーザー個別）とグローバルステート（全ユーザー間で同期）のサンプル実装

### UI改善
- 🎨 ボタンのラベルテキストがMeshと重ならないようにZ位置を調整（0 → 0.51）
- 🏷️ ボタンのラベルを「ローカル」「グローバル」に変更し、動作が一目で分かるように

### ドキュメント
- 📝 README.mdに`useInstanceState`フックの詳細な使用方法を追加
  - APIリファレンス
  - コード例
  - ローカル/グローバルステートの使い分けガイド

### 依存関係
- ⬆️ `@xrift/world-components`を0.5.0に更新（`useInstanceState`フックを含むバージョン）

## スクリーンショット

実装例：
- **左のボタン（ローカル）**: 各ユーザーごとに独立したカウント
- **右のボタン（グローバル）**: 全ユーザー間で同期されるカウント

## テスト方法

1. `npm install`で依存関係をインストール
2. `npm run dev`で開発サーバーを起動
3. 2つのボタンをクリックして動作を確認：
   - 「ローカル」ボタン：各タブで独立してカウント
   - 「グローバル」ボタン：複数タブを開いて同時にクリックすると同期を確認可能（本番環境では全ユーザー間で同期）

## 関連ファイル

- `src/components/InteractableButton/index.tsx`: グローバルステート対応の実装
- `src/World.tsx`: ローカル/グローバルボタンの配置
- `README.md`: useInstanceStateの使用方法ドキュメント

🤖 Generated with [Claude Code](https://claude.com/claude-code)