### PR TITLE
feat: @xrift/world-componentsを0.9.0に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/world-template",
       "version": "1.0.0",
       "dependencies": {
-        "@xrift/world-components": "^0.7.0"
+        "@xrift/world-components": "^0.9.0"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1889,9 +1889,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.7.0.tgz",
-      "integrity": "sha512-PRqsKj2jBxhSYKduR3FOjqN0NwJEJRVPXNxBKgj+/1k/JOo/C+vUMTfXMNRKb5vJSdBsxp9UnsB+ZGp4IQxKrg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.9.0.tgz",
+      "integrity": "sha512-tA5DWJkPA/rR8IEobZkCMHkZqn588utCXd2Cwkcz+4W4neSS5/C0w0bRBQ0WyQWyJkIXo5jUGIxf1Qh/1qP2Vg==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.7.0"
+    "@xrift/world-components": "^0.9.0"
   }
 }


### PR DESCRIPTION
## Summary
- @xrift/world-componentsを^0.7.0から^0.9.0に更新
- ビルドエラーを解消

## Test plan
- [x] `npm run build` が正常に完了することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)