### PR TITLE
feat: @xrift/world-componentsを0.10.2に更新しScreenShareDisplayを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/world-template",
       "version": "1.0.0",
       "dependencies": {
-        "@xrift/world-components": "^0.9.0"
+        "@xrift/world-components": "^0.10.2"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1889,9 +1889,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.9.0.tgz",
-      "integrity": "sha512-tA5DWJkPA/rR8IEobZkCMHkZqn588utCXd2Cwkcz+4W4neSS5/C0w0bRBQ0WyQWyJkIXo5jUGIxf1Qh/1qP2Vg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.10.2.tgz",
+      "integrity": "sha512-zJOUikppLtgB2evDaS1y3VCn9b2gx23rk2r0lzsqH11Yklt/iQf9wGB2zIO6m0jbyvq0QPDSrPJDwoGjxNQIeA==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.9.0"
+    "@xrift/world-components": "^0.10.2"
   }
 }

--- a/src/World.tsx
+++ b/src/World.tsx
@@ -1,4 +1,4 @@
-import { Mirror, VideoScreen } from '@xrift/world-components'
+import { Mirror, ScreenShareDisplay, VideoScreen } from '@xrift/world-components'
 import { RigidBody } from '@react-three/rapier'
 import { useRef } from 'react'
 import { Mesh } from 'three'
@@ -30,8 +30,8 @@ export const World: React.FC<WorldProps> = ({ position = [0, 0, 0], scale = 1 })
         position={[10, 10, 5]}
         intensity={1}
         castShadow
-        shadow-mapSize-width={4096}
-        shadow-mapSize-height={4096}
+        shadow-mapSize-width={1024}
+        shadow-mapSize-height={1024}
         shadow-camera-far={50}
         shadow-camera-left={-15}
         shadow-camera-right={15}
@@ -162,6 +162,13 @@ export const World: React.FC<WorldProps> = ({ position = [0, 0, 0], scale = 1 })
         rotation={[0, -Math.PI / 2, 0]}
         url='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'
         playing
+      />
+
+      {/* 画面共有ディスプレイ - 左側の壁に配置 */}
+      <ScreenShareDisplay
+        id='screen-share-1'
+        position={[-9.72, 2, 0]}
+        rotation={[0, Math.PI / 2, 0]}
       />
 
       {/* アニメーション: ぐるぐる回るオブジェクト */}


### PR DESCRIPTION
## Summary

- @xrift/world-componentsを0.9.0から0.10.2に更新
- ScreenShareDisplayコンポーネントを左側の壁に追加
- 影の解像度を4096から1024に変更（パフォーマンス改善）

## Test plan

- [ ] `npm run dev`でローカル動作確認
- [ ] 影の描画が正常に表示されること
- [ ] ScreenShareDisplayが左側の壁に配置されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)