### PR TITLE
feat: VideoScreen を RichVideoPlayer に置き換え

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,13 @@ const model = useGLTF(`${baseUrl}/models/robot.glb`) // 余分な / NG
 | `Interactable` | クリック可能オブジェクト | `id`(必須), `onInteract`(必須), `interactionText`, `enabled` |
 | `SpawnPoint` | プレイヤー出現地点 | `position`, `yaw`(0-360度) |
 | `Mirror` | 反射面 | `position`, `rotation`, `size`, `color`, `textureResolution` |
-| `VideoScreen` | 動画再生 | `id`(必須), `position`, `url`, `playing`, `sync` |
+| `RichVideoPlayer` | UI付き動画再生（推奨） | `id`(必須), `url`(必須), `position`, `rotation`, `width`, `playing`, `volume`, `sync` |
+| `VideoScreen` | 基本動画再生 | `id`(必須), `position`, `url`, `playing`, `sync` |
 | `ScreenShareDisplay` | 画面共有表示 | `id`(必須), `position`, `rotation`, `width` |
+
+**RichVideoPlayer vs VideoScreen**:
+- `RichVideoPlayer`: UIコントロール付き（再生/一時停止、進捗バー、音量調整）、VR対応
+- `VideoScreen`: シンプルな同期映像表示のみ
 
 ---
 

--- a/agent.md
+++ b/agent.md
@@ -49,8 +49,13 @@ const model = useGLTF(`${baseUrl}/models/robot.glb`) // 余分な / NG
 | `Interactable` | クリック可能オブジェクト | `id`(必須), `onInteract`(必須), `interactionText`, `enabled` |
 | `SpawnPoint` | プレイヤー出現地点 | `position`, `yaw`(0-360度) |
 | `Mirror` | 反射面 | `position`, `rotation`, `size`, `color`, `textureResolution` |
-| `VideoScreen` | 動画再生 | `id`(必須), `position`, `url`, `playing`, `sync` |
+| `RichVideoPlayer` | UI付き動画再生（推奨） | `id`(必須), `url`(必須), `position`, `rotation`, `width`, `playing`, `volume`, `sync` |
+| `VideoScreen` | 基本動画再生 | `id`(必須), `position`, `url`, `playing`, `sync` |
 | `ScreenShareDisplay` | 画面共有表示 | `id`(必須), `position`, `rotation`, `width` |
+
+**RichVideoPlayer vs VideoScreen**:
+- `RichVideoPlayer`: UIコントロール付き（再生/一時停止、進捗バー、音量調整）、VR対応
+- `VideoScreen`: シンプルな同期映像表示のみ
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/world-template",
       "version": "1.0.0",
       "dependencies": {
-        "@xrift/world-components": "^0.16.0"
+        "@xrift/world-components": "^0.17.1"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1878,9 +1878,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.16.0.tgz",
-      "integrity": "sha512-1vCa3Vafm3rFScvTfhoSqWg4UwehCI28ybzzHBLNSMIt1ta6W5kuncNnPptOXPQ35+KGBmhxvMETyPBVjdceQg==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.17.1.tgz",
+      "integrity": "sha512-bG4pXweottlKvEE/ADP0CDUvfu+PvORan1adtmV4A1RDXguS0/mRnsZxccui0fyGAdrJMVu4/OQo8jVCi6VAdA==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.16.0"
+    "@xrift/world-components": "^0.17.1"
   }
 }

--- a/src/World.tsx
+++ b/src/World.tsx
@@ -1,4 +1,4 @@
-import { Mirror, ScreenShareDisplay, SpawnPoint, VideoScreen } from '@xrift/world-components'
+import { Mirror, RichVideoPlayer, ScreenShareDisplay, SpawnPoint } from '@xrift/world-components'
 import { RigidBody } from '@react-three/rapier'
 import { useRef } from 'react'
 import { Mesh } from 'three'
@@ -162,10 +162,11 @@ export const World: React.FC<WorldProps> = ({ position = [0, 0, 0], scale = 1 })
         size={[4 * scale, 3 * scale]}
       />
 
-      <VideoScreen
+      <RichVideoPlayer
         id='sample-video'
         position={[9.72, 2, 0]}
         rotation={[0, -Math.PI / 2, 0]}
+        width={4}
         url='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'
         playing
       />


### PR DESCRIPTION
## Summary
- `VideoScreen` を UIコントロール付きの `RichVideoPlayer` に置き換え
- `CLAUDE.md` / `agent.md` のコンポーネント一覧を更新
- `@xrift/world-components` を 0.17.1 にアップデート

## Test plan
- [ ] `npm run dev` でワールドが正常に起動することを確認
- [ ] ビデオプレーヤーの再生/一時停止が動作することを確認
- [ ] 音量調整が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)