### PR TITLE
refactor: VideoScreen を VideoPlayer に置き換え

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,10 @@ const model = useGLTF(`${baseUrl}/models/robot.glb`) // 余分な / NG
 | `Interactable` | クリック可能オブジェクト | `id`(必須), `onInteract`(必須), `interactionText`, `enabled` |
 | `SpawnPoint` | プレイヤー出現地点 | `position`, `yaw`(0-360度) |
 | `Mirror` | 反射面 | `position`, `rotation`, `size`, `color`, `textureResolution` |
-| `VideoScreen` | 動画再生 | `id`(必須), `position`, `url`, `playing`, `sync` |
+| `VideoPlayer` | UI付き動画再生 | `id`(必須), `url`(必須), `position`, `rotation`, `width`, `playing`, `volume`, `sync` |
 | `ScreenShareDisplay` | 画面共有表示 | `id`(必須), `position`, `rotation`, `width` |
+
+**VideoPlayer**: UIコントロール付き（再生/一時停止、進捗バー、音量調整、URL入力）、VR対応
 
 ---
 

--- a/agent.md
+++ b/agent.md
@@ -49,8 +49,10 @@ const model = useGLTF(`${baseUrl}/models/robot.glb`) // 余分な / NG
 | `Interactable` | クリック可能オブジェクト | `id`(必須), `onInteract`(必須), `interactionText`, `enabled` |
 | `SpawnPoint` | プレイヤー出現地点 | `position`, `yaw`(0-360度) |
 | `Mirror` | 反射面 | `position`, `rotation`, `size`, `color`, `textureResolution` |
-| `VideoScreen` | 動画再生 | `id`(必須), `position`, `url`, `playing`, `sync` |
+| `VideoPlayer` | UI付き動画再生 | `id`(必須), `url`(必須), `position`, `rotation`, `width`, `playing`, `volume`, `sync` |
 | `ScreenShareDisplay` | 画面共有表示 | `id`(必須), `position`, `rotation`, `width` |
+
+**VideoPlayer**: UIコントロール付き（再生/一時停止、進捗バー、音量調整、URL入力）、VR対応
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/world-template",
       "version": "1.0.0",
       "dependencies": {
-        "@xrift/world-components": "^0.16.0"
+        "@xrift/world-components": "^0.20.0"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1878,15 +1878,21 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.16.0.tgz",
-      "integrity": "sha512-1vCa3Vafm3rFScvTfhoSqWg4UwehCI28ybzzHBLNSMIt1ta6W5kuncNnPptOXPQ35+KGBmhxvMETyPBVjdceQg==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.20.0.tgz",
+      "integrity": "sha512-cIuTj2YYQqWq6OlWyDyZXXFDTaS91sCd2NVgnZZlg7ecDXJqdtUKuuAnvAHQQ6PhX893ozrJNOs1Fa6aDY3rag==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",
         "@react-three/fiber": "^9.0.0",
+        "hls.js": "^1.5.0",
         "react": "^18.0.0 || ^19.0.0",
         "three": ">=0.176.0"
+      },
+      "peerDependenciesMeta": {
+        "hls.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.16.0"
+    "@xrift/world-components": "^0.20.0"
   }
 }

--- a/src/World.tsx
+++ b/src/World.tsx
@@ -1,4 +1,4 @@
-import { Mirror, ScreenShareDisplay, SpawnPoint, VideoScreen } from '@xrift/world-components'
+import { Mirror, ScreenShareDisplay, SpawnPoint, VideoPlayer } from '@xrift/world-components'
 import { RigidBody } from '@react-three/rapier'
 import { useRef } from 'react'
 import { Mesh } from 'three'
@@ -162,10 +162,11 @@ export const World: React.FC<WorldProps> = ({ position = [0, 0, 0], scale = 1 })
         size={[4 * scale, 3 * scale]}
       />
 
-      <VideoScreen
+      <VideoPlayer
         id='sample-video'
         position={[9.72, 2, 0]}
         rotation={[0, -Math.PI / 2, 0]}
+        width={4}
         url='https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'
         playing
       />


### PR DESCRIPTION
## Summary
- @xrift/world-components を 0.20.0 に更新
- VideoScreen を VideoPlayer に置き換え（UIコントロール付き動画プレイヤー）
- CLAUDE.md と agent.md のドキュメントを更新

## 背景
xrift-world-components の [PR #71](https://github.com/WebXR-JP/xrift-world-components/pull/71) で RichVideoPlayer が VideoPlayer にリネームされたため、本リポジトリでも対応。

## Test plan
- [x] 型チェック通過
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)