### PR TITLE
feat: カメラ near/far クリッピング設定のサンプルを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/world-template",
       "version": "1.0.0",
       "dependencies": {
-        "@xrift/world-components": "^0.30.5"
+        "@xrift/world-components": "^0.31.2"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1879,9 +1879,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.30.5",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.30.5.tgz",
-      "integrity": "sha512-lQIczHqYezteKPk8S17qyOUGcp1ZghHDGWo6nwle8tfSPdW+CNP95ZpZXUE1ulDlrHyQ+26hBoTwuJaHSFYlJg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.31.2.tgz",
+      "integrity": "sha512-kOJb+E5kC2E6QBJyWki6CKwbpqH8ASAt2g1Mpapve/UP6wrPtfNtYPfJnXkHBCMg5C4D5TMee/fHCh5yCavQUQ==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.30.5"
+    "@xrift/world-components": "^0.31.2"
   }
 }

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -6,7 +6,7 @@
  */
 
 import { DevEnvironment, XRiftProvider } from '@xrift/world-components'
-import type { PhysicsConfig } from '@xrift/world-components'
+import type { CameraConfig, PhysicsConfig } from '@xrift/world-components'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { World } from './World'
@@ -19,10 +19,14 @@ const physicsConfig: PhysicsConfig | undefined = (
   xriftConfig as { physics?: PhysicsConfig }
 ).physics
 
+const cameraConfig: CameraConfig | undefined = (
+  xriftConfig as { camera?: CameraConfig }
+).camera
+
 createRoot(rootElement).render(
   <StrictMode>
     <XRiftProvider baseUrl="/">
-      <DevEnvironment physicsConfig={physicsConfig}>
+      <DevEnvironment physicsConfig={physicsConfig} camera={cameraConfig}>
         <World />
       </DevEnvironment>
     </XRiftProvider>

--- a/xrift.json
+++ b/xrift.json
@@ -26,6 +26,10 @@
     "physics": {
       "gravity": 9.81,
       "allowInfiniteJump": true
+    },
+    "camera": {
+      "near": 0.1,
+      "far": 1000
     }
   }
 }


### PR DESCRIPTION
## Summary
- `@xrift/world-components` を v0.31.2 に更新（`CameraConfig` 型の追加）
- `xrift.json` にカメラ設定のサンプル値（`near: 0.1`, `far: 1000`）を追加
- `dev.tsx` で `CameraConfig` を import し、`DevEnvironment` に `camera` prop を渡すよう更新

## 関連PR
- WebXR-JP/xrift-world-components#134
- WebXR-JP/xrift-cli#45
- WebXR-JP/xrift-docs#49

## Test plan
- [x] `npm run typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)