### PR TITLE
ワールドアップロード時にエラーが発生しないようにvite.config.ts の修正

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,9 +35,6 @@ export default defineConfig({
           singleton: true,
           requiredVersion: '^0.176.0',
         },
-        'three/addons': {
-          singleton: true,
-        },
         '@react-three/fiber': {
           singleton: true,
           requiredVersion: '^9.3.0',


### PR DESCRIPTION
### 概要
ビルド後のコードに `eval` が含まれるのを防ぐため、`vite.config.ts` から不要な `three/addons` の設定を削除しました。

### 変更内容
- `vite.config.ts` 内の `federation` 設定から `three/addons` の定義を削除。

### 影響範囲
- ビルド成果物: 生成される JS ファイルから eval が排除されます。
- これにより、ワールドアップロードエラーが発生しなくなります。