### PR TITLE
fix: share DRACOLoader subpath to fix new Worker() security violation

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
           singleton: true,
           requiredVersion: '^0.176.0',
         },
+        'three/addons/loaders/DRACOLoader.js': {
+          singleton: true,
+        },
         '@react-three/fiber': {
           singleton: true,
           requiredVersion: '^9.3.0',

--- a/xrift.json
+++ b/xrift.json
@@ -16,6 +16,7 @@
       "**/__federation_shared_@react-three/rapier-*.js",
       "**/__federation_shared_@xrift/world-components-*.js",
       "**/__federation_shared_three-*.js",
+      "**/__federation_shared_three/addons/**",
       "**/__federation_shared_react-*.js",
       "**/__federation_shared_react-dom-*.js",
       "**/__federation_shared_react-dom/client-*.js",


### PR DESCRIPTION
## Summary
- `three/addons/loaders/DRACOLoader.js` をサブパス単位で Module Federation の shared に追加
- `xrift.json` の ignore に `three/addons` shared チャンクのパターンを追加

## 背景
- PR #110 で `three/addons` を shared から削除（Lottie 由来の `eval` 回避のため）
- しかし DRACOLoader がワールドチャンクにインライン化され、内部の `new Worker()` がセキュリティチェック違反に

## 解決策
バレルファイル（`Addons.js`）全体ではなく、使用するアドオンのサブパスのみを shared 化することで：
- ❌ `eval` → Lottie を含むバレルファイルをバンドルしないため発生しない
- ❌ `new Worker()` → DRACOLoader が shared チャンクに分離されるため World チャンクには含まれない

## Test plan
- [x] `npm run build` 成功
- [x] World チャンクに `new Worker()` / `eval` が含まれないことを確認
- [x] `world-test` 環境で `xrift upload` のセキュリティチェック通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)