### PR TITLE
feat: xrift.json の outputBufferType を DevEnvironment に反映

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/world-template",
       "version": "1.0.0",
       "dependencies": {
-        "@xrift/world-components": "^0.31.2"
+        "@xrift/world-components": "^0.36.1"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1879,20 +1879,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.31.2",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.31.2.tgz",
-      "integrity": "sha512-kOJb+E5kC2E6QBJyWki6CKwbpqH8ASAt2g1Mpapve/UP6wrPtfNtYPfJnXkHBCMg5C4D5TMee/fHCh5yCavQUQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.36.1.tgz",
+      "integrity": "sha512-mSXA3Ibe0eZcPMbl8JZ7VB18syYf6AqnYn25N+nylqoPFuddPp/ZIO/bxm8TOltBSWmCC2exmUNMWgY40vpm8w==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",
         "@react-three/fiber": "^9.0.0",
         "@react-three/rapier": "^2.0.0",
+        "@react-three/uikit": "^1.0.0",
         "hls.js": "^1.5.0",
         "react": "^18.0.0 || ^19.0.0",
         "three": ">=0.176.0"
       },
       "peerDependenciesMeta": {
         "@react-three/rapier": {
+          "optional": true
+        },
+        "@react-three/uikit": {
           "optional": true
         },
         "hls.js": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.31.2"
+    "@xrift/world-components": "^0.36.1"
   }
 }

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -15,18 +15,20 @@ import xriftConfig from '../xrift.json'
 const rootElement = document.getElementById('root')
 if (!rootElement) throw new Error('Root element not found')
 
-const physicsConfig: PhysicsConfig | undefined = (
-  xriftConfig as { physics?: PhysicsConfig }
-).physics
-
-const cameraConfig: CameraConfig | undefined = (
-  xriftConfig as { camera?: CameraConfig }
-).camera
+const worldConfig = xriftConfig.world as {
+  physics?: PhysicsConfig
+  camera?: CameraConfig
+  outputBufferType?: string
+}
 
 createRoot(rootElement).render(
   <StrictMode>
     <XRiftProvider baseUrl="/">
-      <DevEnvironment physicsConfig={physicsConfig} camera={cameraConfig}>
+      <DevEnvironment
+        physicsConfig={worldConfig.physics}
+        camera={worldConfig.camera}
+        outputBufferType={worldConfig.outputBufferType}
+      >
         <World />
       </DevEnvironment>
     </XRiftProvider>


### PR DESCRIPTION
## Summary
- `@xrift/world-components` を `^0.36.1` にアップデート（`outputBufferType` prop 対応）
- `xrift.json` の `world.outputBufferType` を読み取り `DevEnvironment` に渡すように追加
- `xriftConfig.world` から正しく config を読み取るよう修正（`physics` / `camera` が常に `undefined` になるバグも修正）

## 関連
- WebXR-JP/xrift-world-components#164

## Test plan
- [ ] `xrift.json` に `"outputBufferType": "HalfFloatType"` を追加して `npm run dev` で描画が反映されることを確認
- [ ] `outputBufferType` 未設定時にデフォルト動作（UnsignedByteType）になることを確認
- [ ] `npm run typecheck` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)