### PR TITLE
fix: add @react-three/uikit as shared dependency to fix build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@react-three/rapier": "^2.2.0",
+        "@react-three/uikit": "^1.0.64",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.183.1",
@@ -1012,6 +1013,58 @@
         "node": ">=12"
       }
     },
+    "node_modules/@pmndrs/msdfonts": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@pmndrs/msdfonts/-/msdfonts-1.0.64.tgz",
+      "integrity": "sha512-fyDNvCIGUTUYxDOzQnLOAGEuDQbyjx1JUlEYrjHB8KLDWzVl0j2SoFiLN4AwahEh4pXiA7XdJBNneQKnfMa/Bw==",
+      "devOptional": true,
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@pmndrs/pointer-events": {
+      "version": "6.6.29",
+      "resolved": "https://registry.npmjs.org/@pmndrs/pointer-events/-/pointer-events-6.6.29.tgz",
+      "integrity": "sha512-o4YD6VfJgDYjFgde/YyAw2X5KY454tdmOXrHGOvKTWJBHzkL90B5vH4rqmexwRVvaDfT3YLvVh/Dm5cBbgZXMg==",
+      "devOptional": true,
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@pmndrs/uikit": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@pmndrs/uikit/-/uikit-1.0.64.tgz",
+      "integrity": "sha512-FQgF8sf46U6fmHnqOn32S04lnWiXVxQO6MatL7FgoLKJ74YIBgEHgwKHRwltgLrN/rcTu7LgJm7LgvXvMccEGA==",
+      "devOptional": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@pmndrs/msdfonts": "^1.0.64",
+        "@pmndrs/uikit-pub-sub": "^1.0.64",
+        "@preact/signals-core": "^1.5.1",
+        "@zappar/msdf-generator": "^1.2.4",
+        "yoga-layout": "^3.2.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.162"
+      }
+    },
+    "node_modules/@pmndrs/uikit-pub-sub": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@pmndrs/uikit-pub-sub/-/uikit-pub-sub-1.0.64.tgz",
+      "integrity": "sha512-+hlc5aWC3wQlA/zihwh+OGSm3aY9O+L/TEuNLwXw6R8syHMv7obqeY6s/hcjzD92k6DRQZLhVzVy+yqqVKAbRA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.8.0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@react-three/drei": {
       "version": "10.7.7",
       "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
@@ -1114,6 +1167,24 @@
         "@react-three/fiber": "^9.0.4",
         "react": "^19",
         "three": ">=0.159.0"
+      }
+    },
+    "node_modules/@react-three/uikit": {
+      "version": "1.0.64",
+      "resolved": "https://registry.npmjs.org/@react-three/uikit/-/uikit-1.0.64.tgz",
+      "integrity": "sha512-//wUWePJHHHWgDokWs2WUs8yUqOJ1Dy/g1OufGHw/BeTujtoNG0hmuISjdeDXZOQPfNjpMgrbemfmvryTeCfLg==",
+      "devOptional": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@pmndrs/pointer-events": "^6.6.29",
+        "@pmndrs/uikit": "^1.0.64",
+        "@preact/signals-core": "^1.5.1",
+        "suspend-react": "^0.1.3",
+        "zustand": "^5.0.6"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8",
+        "react": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1904,6 +1975,19 @@
         }
       }
     },
+    "node_modules/@zappar/msdf-generator": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@zappar/msdf-generator/-/msdf-generator-1.2.4.tgz",
+      "integrity": "sha512-6S/MCk0Ky0ipewZJw4xFEzH/2aYfWmPXEkTdBtNyDDfkbicrNwgJgtxZ4SnTDyNe9XHMqDA4sL9srRsgDLRMqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "comlink": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2134,6 +2218,13 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
@@ -3529,6 +3620,13 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/zustand": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@react-three/rapier": "^2.2.0",
+    "@react-three/uikit": "^1.0.64",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.183.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
           singleton: true,
           requiredVersion: '^10.7.3',
         },
+        '@react-three/uikit': {
+          singleton: true,
+          requiredVersion: '^1.0.0',
+        },
         '@xrift/world-components': {
           singleton: true,
           requiredVersion: '^0.1.0',


### PR DESCRIPTION
## Summary
- `@react-three/uikit` を devDependencies に追加し、vite.config.ts の shared 設定にも追加
- `@xrift/world-components` の `useDefaultFont` が内部的に `@pmndrs/uikit` を動的 import しているが、未インストールのため Rollup のビルドが失敗していた

## Test plan
- [x] `npm run build` が成功することを確認済み
- [ ] `npm run dev` で開発サーバーが正常に起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)