### PR TITLE
chore: skills-lock.json を追加し .agents を gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist
 
 # XRift
 .xrift
+
+# Skills
+.agents

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "xrift-world": {
+      "source": "WebXR-JP/xrift-skills",
+      "sourceType": "github",
+      "computedHash": "b048508f69a9dd33a2d4a58678120f274debe54f8c9e85b5e94c9a799401dc7b"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `xrift-skills` のバージョン固定のため `skills-lock.json` をリポジトリに追加
- `npx skills add` で生成される再生成可能な `.agents/` ディレクトリを `.gitignore` に追加

## Test plan
- [ ] `npx skills add WebXR-JP/xrift-skills` を実行しても `.agents/` が untracked にならないこと
- [ ] `skills-lock.json` の内容で意図したバージョンが固定されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)