### PR TITLE
fix: shared の requiredVersion と world-components のバージョンを更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@xrift/world-template",
       "version": "1.0.0",
       "dependencies": {
-        "@xrift/world-components": "^0.36.1"
+        "@xrift/world-components": "^0.41.0"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -1950,9 +1950,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@xrift/world-components": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.36.1.tgz",
-      "integrity": "sha512-mSXA3Ibe0eZcPMbl8JZ7VB18syYf6AqnYn25N+nylqoPFuddPp/ZIO/bxm8TOltBSWmCC2exmUNMWgY40vpm8w==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@xrift/world-components/-/world-components-0.41.0.tgz",
+      "integrity": "sha512-fZL622Zogh3lepgo3lFwsDr1vZWDDWkxdqqEbpzb0x91hgf+jxTCZkBuu1fepYmCosARp7VMeEnRrzex17FOug==",
       "license": "MIT",
       "peerDependencies": {
         "@react-three/drei": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@xrift/world-components": "^0.36.1"
+    "@xrift/world-components": "^0.41.0"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         },
         three: {
           singleton: true,
-          requiredVersion: '^0.176.0',
+          requiredVersion: '^0.183.1',
         },
         'three/addons/loaders/DRACOLoader.js': {
           singleton: true,
@@ -56,7 +56,7 @@ export default defineConfig({
         },
         '@xrift/world-components': {
           singleton: true,
-          requiredVersion: '^0.1.0',
+          requiredVersion: '^0.41.0',
         },
       },
     }),


### PR DESCRIPTION
## Summary
- `vite.config.ts` の Module Federation `shared` 設定で実バージョンと非互換だった `requiredVersion` を修正
  - `three`: `^0.176.0` → `^0.183.1`
  - `@xrift/world-components`: `^0.1.0` → `^0.41.0`
- `@xrift/world-components` の依存バージョンを `^0.36.1` → `^0.41.0` に bump（host / item-template と semver 範囲を合わせる）

## 背景
host (xrift-frontend) が PR https://github.com/WebXR-JP/xrift-frontend/pull/1267 で `@xrift/world-components` の `requiredVersion` を `^0.41.0` に更新したが、world-template 側はまだ `^0.1.0` のままで Module Federation の shared 解決ができず、host とマージしたタイミングでワールド読み込みが壊れる。

0.x 系は npm の semver 上「minor が breaking」扱いのため、`^0.1.0` は `0.41.x` と範囲が交わらない。

合わせて、`three` も `^0.176.0` のまま実バージョン `^0.183.1` と非互換だったので修正。

item-template の同等修正は https://github.com/WebXR-JP/xrift-item-template/pull/7 で対応済み。

## Test plan
- [x] \`npm install\` でパッチ等のエラーなく完走（確認済み）
- [x] \`npx tsc --noEmit\` でエラーなし
- [x] \`npm run build\` 成功
- [ ] host (PR #1267) と一緒にマージし、既存ワールド (lobby, nade1 など) が引き続き読み込めることを確認
- [ ] CLI でテンプレートから新規ワールドを生成 → \`xrift deploy\` → host で正常表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)