### PR TITLE
fix: shared dependencies の requiredVersion を '*' に緩める

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,11 +19,11 @@ export default defineConfig({
       shared: {
         react: {
           singleton: true,
-          requiredVersion: '^19.0.0',
+          requiredVersion: '*',
         },
         'react-dom': {
           singleton: true,
-          requiredVersion: '^19.0.0',
+          requiredVersion: '*',
         },
         'react-dom/client': {
           singleton: true,
@@ -33,30 +33,30 @@ export default defineConfig({
         },
         three: {
           singleton: true,
-          requiredVersion: '^0.183.1',
+          requiredVersion: '*',
         },
         'three/addons/loaders/DRACOLoader.js': {
           singleton: true,
         },
         '@react-three/fiber': {
           singleton: true,
-          requiredVersion: '^9.3.0',
+          requiredVersion: '*',
         },
         '@react-three/rapier': {
           singleton: true,
-          requiredVersion: '^2.1.0',
+          requiredVersion: '*',
         },
         '@react-three/drei': {
           singleton: true,
-          requiredVersion: '^10.7.3',
+          requiredVersion: '*',
         },
         '@react-three/uikit': {
           singleton: true,
-          requiredVersion: '^1.0.0',
+          requiredVersion: '*',
         },
         '@xrift/world-components': {
           singleton: true,
-          requiredVersion: '^0.41.0',
+          requiredVersion: '*',
         },
       },
     }),


### PR DESCRIPTION
## Summary
- federation の `requiredVersion` を全 shared dep で `'*'` に変更
- host 側のバージョン上げに自動追随できるようになる
- Closes #125

## 背景

federation の `requiredVersion` を `^<実バージョン>` で焼き込んでいたため、host のバージョン上げに追随できずワールド読み込み時に satisfy 不能になり 404 で落ちる問題があった。

特に semver の `^0.x.y` は patch しか許可しない (`>=0.x.y <0.(x+1).0`)。今回 host が `@xrift/world-components` を `0.1.0` → `0.41.0` に上げたタイミングで、現 template (`^0.41.0`) で publish 済みのワールドが旧 host 環境で壊れる現象が発生した。

## なぜ `'*'` で安全か

- federation の `requiredVersion` は **version negotiation のラベル** で、互換性保証ではない
- singleton の実体は host の `node_modules` 上 1 つに集約される
- API 互換性は host 側 `package.json` の version range で別途担保される
- ワールド bundle は host と同じバージョンで動作することを前提に build されているため、host の version 表記に厳しくする意味は薄い

## 影響範囲

- 既に publish 済みのワールドはこの修正の対象外（bundle に焼かれてるため再 build & 再 publish が必要）
- 今後 build される全ワールドが host の version 上げに自動追随する

## Test plan
- [x] `npm run typecheck` が pass する
- [ ] `npm run build` が成功する
- [ ] build された `dist/__federation_fn_import-*.js` 内で `requiredVersion: '*'` になっていることを確認
- [ ] 実際にこのテンプレートからワールドを publish して、host 環境で正常に読み込めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)